### PR TITLE
GHC 8.8 compatibility

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -36,10 +36,11 @@ library:
     base: '>= 4.7 && < 5'
     bytestring: '>= 0.10.8 && < 0.11'
     directory: '>= 1.3 && < 1.4'
+    extra:
     filepath: '>= 1.4.1 && < 1.5'
-    path: '>= 0.5 && < 0.7'
+    path: '>= 0.5 && < 0.8'
     # tar: '>= 0.5 && < 0.6'
-    zip: '>= 1.0 && < 1.3'
+    zip: '>= 1.0 && < 1.4'
     zlib: '>= 0.6 && < 0.7'
     # For Codec.Archive.Tar
     deepseq:

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,8 @@ when:
       - -Wincomplete-record-updates
       - -Wincomplete-uni-patterns
       - -Wnoncanonical-monad-instances
+  - condition: impl(ghc <= 8.6)
+    ghc-options:
       - -Wnoncanonical-monadfail-instances
 
 library:
@@ -69,11 +71,11 @@ tests:
     dependencies:
       base:
       bytestring:
-      bytestring-arbitrary:
       filepath:
       path:
       path-io:
       QuickCheck:
+      quickcheck-instances:
       tasty:
       tasty-quickcheck:
       ztar:

--- a/package.yaml
+++ b/package.yaml
@@ -38,7 +38,6 @@ library:
     base: '>= 4.7 && < 5'
     bytestring: '>= 0.10.8 && < 0.11'
     directory: '>= 1.3 && < 1.4'
-    extra:
     filepath: '>= 1.4.1 && < 1.5'
     path: '>= 0.5 && < 0.8'
     # tar: '>= 0.5 && < 0.6'

--- a/src/Codec/Archive/ZTar/Zip.hs
+++ b/src/Codec/Archive/ZTar/Zip.hs
@@ -18,7 +18,7 @@ module Codec.Archive.ZTar.Zip
   ) where
 
 import qualified Codec.Archive.Zip as Zip
-import Control.Monad.Extra (concatMapM)
+import Control.Monad (liftM)
 import Control.Monad.IO.Class (liftIO)
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy as BS
@@ -77,6 +77,7 @@ create archive base paths = do
     insertFile path = do
       path' <- Zip.mkEntrySelector path
       Zip.loadEntry Zip.BZip2 path' path
+    concatMapM f = liftM concat . mapM f
 
 -- | Extract all the files contained in an archive compressed with Zip.
 --

--- a/src/Codec/Archive/ZTar/Zip.hs
+++ b/src/Codec/Archive/ZTar/Zip.hs
@@ -73,7 +73,7 @@ create archive base paths = do
     searchDir :: FilePath -> IO [FilePath]
     searchDir path =
       let mkPath = if path == "." then id else (path </>)
-      in concatMapM (search . mkPath) =<< liftIO (listDirectory path)
+      in concatMapM (search . mkPath) =<< listDirectory path
     insertFile path = do
       path' <- Zip.mkEntrySelector path
       Zip.loadEntry Zip.BZip2 path' path

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -3,7 +3,6 @@
 import Codec.Archive.ZTar
 import Control.Monad (forM, forM_)
 import qualified Data.ByteString as BS
-import Data.ByteString.Arbitrary (ArbByteString(..))
 import Data.List (isPrefixOf, nub)
 import Data.Maybe (fromJust)
 import Path
@@ -22,6 +21,7 @@ import Path
 import Path.IO (doesFileExist, ensureDir, isLocationOccupied, withTempDir)
 import qualified System.FilePath.Windows as Windows
 import Test.QuickCheck
+import Test.QuickCheck.Instances.ByteString ()
 import Test.QuickCheck.Monadic
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -103,7 +103,7 @@ arbitraryFileTree = mkFileTree Nothing (0 :: Int)
         isFile <- frequency [(1, pure False), (2^depth, pure True)]
         if isFile
           then do
-            Blind (ABS contents) <- arbitrary
+            Blind contents <- arbitrary
             return [(dir `maybeSlash` toRelFile path, contents)]
           else mkFileTree (Just $ dir `maybeSlash` toRelDir path) (depth + 1)
 


### PR DESCRIPTION
* `fail` was being applied to `ZipArchive` which no longer had a compatible instance.
* failure was due to IO issues, so a simple `liftIO` would have been sufficient.
* However, I separated the IO actions from the ZipArchive action instead of mixing them together.
* Using an up-to-date package that provides arbitrary bytestring instances.

ghc8.8.3 works locally for me now.
```bash
stack --resolver lts-15.11 build
stack --resolver lts-15.11 test
stack --resolver lts-15.11 install hlint stylish-haskell
stack --resolver lts-15.11 exec hlint .
find . -iname \*.hs -exec stack --resolver lts-15.11 exec stylish-haskell -- --inplace '{}' \;
```

Resolves #33 